### PR TITLE
Add framework target option to command line

### DIFF
--- a/src/Facility.CodeGen.AspNet/AspNetGenerator.cs
+++ b/src/Facility.CodeGen.AspNet/AspNetGenerator.cs
@@ -22,6 +22,11 @@ namespace Facility.CodeGen.AspNet
 		public string ApiNamespaceName { get; set; }
 
 		/// <summary>
+		/// The target framework (optional, defaults to webapi).
+		/// </summary>
+		public TargetFramework Target { get; set; }
+
+		/// <summary>
 		/// Generates the ASP.NET controller.
 		/// </summary>
 		protected override CodeGenOutput GenerateOutputCore(ServiceInfo serviceInfo)
@@ -42,8 +47,8 @@ namespace Facility.CodeGen.AspNet
 					"System.Net.Http",
 					"System.Threading",
 					"System.Threading.Tasks",
-					"System.Web.Http",
 					"Facility.Core",
+					Target == TargetFramework.WebApi ? "System.Web.Http" : "Microsoft.AspNetCore.Mvc",
 					apiNamespaceName
 				};
 				CSharpUtility.WriteUsings(code, usings, namespaceName);

--- a/src/Facility.CodeGen.AspNet/Facility.CodeGen.AspNet.csproj
+++ b/src/Facility.CodeGen.AspNet/Facility.CodeGen.AspNet.csproj
@@ -43,6 +43,7 @@
     </Compile>
     <Compile Include="AspNetGenerator.cs" />
     <Compile Include="CSharpUtility.cs" />
+    <Compile Include="TargetFramework.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Facility.CodeGen.AspNet/TargetFramework.cs
+++ b/src/Facility.CodeGen.AspNet/TargetFramework.cs
@@ -1,0 +1,18 @@
+namespace Facility.CodeGen.AspNet
+{
+	/// <summary>
+	/// Used to determine which version of the framework the code should be built for.
+	/// </summary>
+	public enum TargetFramework
+	{
+		/// <summary>
+		/// Target ASP.NET Web API 2.
+		/// </summary>
+		WebApi,
+
+		/// <summary>
+		/// Build for ASP.NET Core 2.0.
+		/// </summary>
+		Core,
+	}
+}

--- a/src/fsdgenaspnet/FsdGenAspNetApp.cs
+++ b/src/fsdgenaspnet/FsdGenAspNetApp.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using ArgsReading;
 using Facility.CodeGen.AspNet;
 using Facility.CodeGen.Console;
@@ -24,6 +25,8 @@ namespace fsdgenaspnet
 			"      The namespace used by the generated code.",
 			"   --apinamespace <name>",
 			"      The namespace used by the API class library.",
+			"   --target (webapi|core)",
+			"      The target framework to write code against. (default `webapi`)",
 		};
 
 		protected override CodeGenerator CreateGenerator(ArgsReader args)
@@ -32,7 +35,22 @@ namespace fsdgenaspnet
 			{
 				NamespaceName = args.ReadOption("namespace"),
 				ApiNamespaceName = args.ReadOption("apinamespace"),
+				Target = ReadTargetOption(args),
 			};
+		}
+
+		public static TargetFramework ReadTargetOption(ArgsReader args)
+		{
+			string value = args.ReadOption("target");
+
+			if (value == null)
+				return TargetFramework.WebApi;
+
+			TargetFramework result;
+			if (!Enum.TryParse(value, ignoreCase: true, result: out result))
+				throw new ArgsReaderException($"Invalid target '{value}'. (Should be 'webapi' or 'core'.)");
+
+			return result;
 		}
 	}
 }


### PR DESCRIPTION
This option adds the ability to target ASP.NET Core 2.0 from the command line.

Default (Original)
--target webapi

Core 2.0
--target core