### PR TITLE
Allow scoped HttpHandlers with UseFacilityHttpHandler.

### DIFF
--- a/src/Facility.AspNetCore/FacilityAspNetCoreMiddleware.cs
+++ b/src/Facility.AspNetCore/FacilityAspNetCoreMiddleware.cs
@@ -16,23 +16,22 @@ namespace Facility.AspNetCore
 		/// <summary>
 		/// Creates an instance.
 		/// </summary>
-		public FacilityAspNetCoreMiddleware(RequestDelegate next, T handler)
+		public FacilityAspNetCoreMiddleware(RequestDelegate next)
 		{
 			m_next = next;
-			m_handler = handler;
 		}
 
 		/// <summary>
 		/// Invokes the middleware.
 		/// </summary>
-		public async Task Invoke(HttpContext httpContext)
+		public async Task Invoke(HttpContext httpContext, T handler)
 		{
 			var httpRequestMessage = FacilityAspNetCoreUtility.CreateHttpRequestMessage(httpContext.Request);
 
 			HttpResponseMessage? httpResponseMessage;
 			try
 			{
-				httpResponseMessage = await m_handler.TryHandleHttpRequestAsync(httpRequestMessage, httpContext.RequestAborted).ConfigureAwait(false);
+				httpResponseMessage = await handler.TryHandleHttpRequestAsync(httpRequestMessage, httpContext.RequestAborted).ConfigureAwait(false);
 			}
 			catch (Exception exception)
 			{
@@ -51,6 +50,5 @@ namespace Facility.AspNetCore
 		}
 
 		private readonly RequestDelegate m_next;
-		private readonly T m_handler;
 	}
 }


### PR DESCRIPTION
Without this change if I try to use a scoped dependency in my API implementation class, I get:

> Cannot consume scoped service 'OrdersApi.v3.Submerchant.Client.ISubmerchantOrdersApiClient' from singleton 'Faithlife.SubmerchantsBff.v1.Client.ISubmerchantsBff'.

If I try to change my API to also be scoped, my handler needs to also be scoped, at which point I get

>Cannot resolve scoped service from root provider

which led me to this StackOverflow article: https://stackoverflow.com/questions/48590579/cannot-resolve-scoped-service-from-root-provider-net-core-2

I would *assume* this change should be backwards compatible but I'm still pretty new to ASP.NET Core DI.

I verified this change fixes my problem by copying the DLL from my local FacilityAspNet to my API's bin folder.