### PR TITLE
Expose request message as http context feature.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>3.13.0</VersionPrefix>
+    <VersionPrefix>3.14.0</VersionPrefix>
     <PackageValidationBaselineVersion>3.12.0</PackageValidationBaselineVersion>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>3.14.0</VersionPrefix>
-    <PackageValidationBaselineVersion>3.12.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>3.13.0</PackageValidationBaselineVersion>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Facility.AspNetCore/FacilityAspNetCoreMiddleware.cs
+++ b/src/Facility.AspNetCore/FacilityAspNetCoreMiddleware.cs
@@ -25,6 +25,7 @@ public sealed class FacilityAspNetCoreMiddleware<T>
 	{
 		var cancellationToken = httpContext.RequestAborted;
 		var httpRequestMessage = FacilityAspNetCoreUtility.CreateHttpRequestMessage(httpContext.Request);
+		httpContext.Features.Set(new FacilityRequestMessageFeature { RequestMessage = httpRequestMessage });
 		var httpResponseMessage = await handler.TryHandleHttpRequestAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false);
 		if (httpResponseMessage != null)
 		{

--- a/src/Facility.AspNetCore/FacilityRequestMessageFeature.cs
+++ b/src/Facility.AspNetCore/FacilityRequestMessageFeature.cs
@@ -1,6 +1,12 @@
 namespace Facility.AspNetCore;
 
+/// <summary>
+/// Exposes the HttpRequestMessage for a facility API request on the http context.
+/// </summary>
 public sealed class FacilityRequestMessageFeature
 {
+	/// <summary>
+	/// The HttpRequestMessage used by facility for the API request.
+	/// </summary>
 	public required HttpRequestMessage RequestMessage { get; init; }
 }

--- a/src/Facility.AspNetCore/FacilityRequestMessageFeature.cs
+++ b/src/Facility.AspNetCore/FacilityRequestMessageFeature.cs
@@ -1,12 +1,12 @@
 namespace Facility.AspNetCore;
 
 /// <summary>
-/// Exposes the HttpRequestMessage for a facility API request on the http context.
+/// Exposes the HttpRequestMessage for a Facility API request using HttpContext.Features.
 /// </summary>
 public sealed class FacilityRequestMessageFeature
 {
 	/// <summary>
-	/// The HttpRequestMessage used by facility for the API request.
+	/// The HttpRequestMessage used by Facility for the API request.
 	/// </summary>
 	public required HttpRequestMessage RequestMessage { get; init; }
 }

--- a/src/Facility.AspNetCore/FacilityRequestMessageFeature.cs
+++ b/src/Facility.AspNetCore/FacilityRequestMessageFeature.cs
@@ -1,0 +1,6 @@
+namespace Facility.AspNetCore;
+
+public sealed class FacilityRequestMessageFeature
+{
+	public required HttpRequestMessage RequestMessage { get; init; }
+}


### PR DESCRIPTION
This will allow consumers to access facility context via the request message outside of aspects. This is useful for telemetry initialization which needs access to the route template used for the request.

I had originally thought to expose facility context on the http context via a common server aspect, but that would require all consumers to specify that aspect which seemed awkward since it's only function would be to expose data used by a different service.

See also https://github.com/FacilityApi/FacilityCSharp/pull/115